### PR TITLE
Fix exception when comparing 64-bit values

### DIFF
--- a/dwarf.py
+++ b/dwarf.py
@@ -2135,7 +2135,7 @@ class DebugAranges:
 
         def __lt__(self, other):
             '''Provide less than comparison for bisect functions'''
-            if type(other) is int:
+            if isinstance(other, (int, long)):
                 return self.address_ranges.max_range.lo < other
             else:
                 return (self.address_ranges.max_range.lo <
@@ -2282,7 +2282,7 @@ class AddressRange:
         return self.lo != other.lo or self.hi != other.hi
 
     def __lt__(self, other):
-        if type(other) is int:
+        if isinstance(other, (int, long)):
             return self.lo < other
         else:
             if self.lo < other.lo:
@@ -2920,7 +2920,7 @@ class LineTable:
                     'children': False}
 
         def __lt__(self, other):
-            if type(other) is int:
+            if isinstance(other, (int, long)):
                 return self.range.lo < other
             return self.range < other.range
 
@@ -3750,7 +3750,7 @@ class CompileUnit:
         self.die_ranges = None
 
     def __lt__(self, other):
-        if type(other) is int:
+        if isinstance(other, (int, long)):
             return self.offset < other
         else:
             raise ValueError


### PR DESCRIPTION
- check if `other` is an instance of `(int,long)`, not just `int`